### PR TITLE
Display reserved rocket in Profile page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import ListMission from './components/pages/listMission/ListMission';
 import ListRocket from './components/pages/ListRocket/ListRocket';
-import Profile from './components/pages/Profile';
+import Profile from './components/pages/Profile/Profile';
 
 function App() {
   return (

--- a/src/components/Navbar.test.js
+++ b/src/components/Navbar.test.js
@@ -111,8 +111,8 @@ describe('Simulate user navaigation interaction', () => {
       </React.StrictMode>,
     );
 
-    const profileLink = screen.getAllByRole('link')[1];
-    fireEvent.click(profileLink);
+    const missionLink = screen.getAllByRole('link')[1];
+    fireEvent.click(missionLink);
 
     expect(window.location.href).toBe((`${defaultRouteUrl}missions`));
   });
@@ -128,8 +128,8 @@ describe('Simulate user navaigation interaction', () => {
       </React.StrictMode>,
     );
 
-    const missionLink = screen.getAllByRole('link')[2];
-    fireEvent.click(missionLink);
+    const profileLink = screen.getAllByRole('link')[2];
+    fireEvent.click(profileLink);
 
     expect(window.location.href).toBe((`${defaultRouteUrl}myprofile`));
   });

--- a/src/components/pages/ListRocket/ListRocket.jsx
+++ b/src/components/pages/ListRocket/ListRocket.jsx
@@ -6,12 +6,13 @@ import { fetchRockets } from '../../../redux/rockets/rocketReducer';
 
 const ListRocket = () => {
   const dispatch = useDispatch();
+  const listRocket = useSelector((state) => state.rocketReducer.listRocket, shallowEqual);
 
   useEffect(() => {
-    dispatch(fetchRockets());
+    if(!listRocket){
+      dispatch(fetchRockets());
+    }
   }, [dispatch]);
-
-  const listRocket = useSelector((state) => state.rocketReducer.listRocket, shallowEqual);
 
   return (
     <ul>

--- a/src/components/pages/Profile.js
+++ b/src/components/pages/Profile.js
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const Profile = () => (
-  <div>Profile</div>
-);
-
-export default Profile;

--- a/src/components/pages/Profile/Profile.css
+++ b/src/components/pages/Profile/Profile.css
@@ -1,0 +1,22 @@
+.profile-rockets,
+.profile-missions {
+  width: 100%;
+}
+
+.list-reserved {
+  width: 80%;
+  border: 1px solid #d3d3d3;
+  border-radius: 12px;
+  margin-top: 24px;
+  min-height: 100px;
+}
+
+.list-reserved li {
+  width: 100%;
+  padding: 12px;
+  border-bottom: 1px solid #d3d3d3;
+}
+
+.list-reserved li:last-child {
+  border: none;
+}

--- a/src/components/pages/Profile/Profile.jsx
+++ b/src/components/pages/Profile/Profile.jsx
@@ -7,9 +7,9 @@ const Profile = () => {
 
   return (<div className='flex-center'>
     <div className="flex-center column profile-missions">
-    <h2>mission</h2>
-    <ul className='no-style flex-center column list-reserved'>
-    </ul>
+      <h2>mission</h2>
+      <ul className='no-style flex-center column list-reserved'>
+      </ul>
     </div>
     <div className="flex-center column profile-rockets">
       <h2>My Rockets</h2>

--- a/src/components/pages/Profile/Profile.jsx
+++ b/src/components/pages/Profile/Profile.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import './Profile.css'
+
+const Profile = () => {
+  const listRocket = useSelector(state=> state.rocketReducer.listRocket)
+
+  return (<div className='flex-center'>
+    <div className="flex-center column profile-missions">
+    <h2>mission</h2>
+    <ul className='no-style flex-center column list-reserved'>
+    </ul>
+    </div>
+    <div className="flex-center column profile-rockets">
+      <h2>My Rockets</h2>
+      <ul className='no-style flex-center column list-reserved'>
+        {(listRocket && listRocket.filter(rocket=> rocket.reserved).length != 0) 
+        ? listRocket.filter(rocket=> rocket.reserved)
+        .map(rocket => (<li key={rocket.id} >{rocket.rocket_name}</li>)) 
+        : "Empty List"
+        }
+      </ul>
+    </div>
+  </div>);
+};
+
+export default Profile;

--- a/src/components/pages/Profile/Profile.test.js
+++ b/src/components/pages/Profile/Profile.test.js
@@ -1,0 +1,87 @@
+import renderer, { act } from 'react-test-renderer';
+import '@testing-library/jest-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import React from 'react';
+import configureStore from '../../../redux/configureStore';
+import Profile from './Profile';
+import { fireEvent, render, screen } from '@testing-library/react';
+import App from '../../../App';
+import { Provider } from 'react-redux';
+
+const listRocketTest = [
+  {
+    id: '5e9d0d95eda69955f709d1eb',
+    rocket_name: 'Falcon 1',
+    description: 'The Falcon 1 was an expendable launch system priva…launch vehicle to go into orbit around the Earth.',
+    flickr_images: 'https://imgur.com/DaCfMsj.jpg',
+  },
+  {
+    id: '5e9d0d95eda69973a809d1ec',
+    rocket_name: 'Falcon 9',
+    description: 'Falcon 9 is a two-stage rocket designed and manufa… satellites and the Dragon spacecraft into orbit.',
+    flickr_images: 'https://farm1.staticflickr.com/929/28787338307_3453a11a77_b.jpg',
+  },
+  {
+    id: '5e9d0d95eda69974db09d1ed',
+    rocket_name: 'Falcon Heavy',
+    description: 'With the ability to lift into orbit over 54 metric…hicle, the Delta IV Heavy, at one-third the cost.',
+    flickr_images: 'https://farm5.staticflickr.com/4599/38583829295_581f34dd84_b.jpg',
+  },
+  {
+    id: '5e9d0d96eda699382d09d1ee',
+    rocket_name: 'Starship',
+    description: 'Starship and Super Heavy Rocket represent a fully …tually replace Falcon 9, Falcon Heavy and Dragon.',
+    flickr_images: 'https://live.staticflickr.com/65535/48954138962_ee541e6755_b.jpg',
+  },
+];
+
+const store = configureStore;
+
+describe('test render of profile', () => {
+  test('Profile should match snapshoot', () => {
+    const tree = renderer.create(
+      <React.StrictMode>
+        <Provider store={store}>
+          <Profile />
+        </Provider>
+      </React.StrictMode>,
+    ).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('test user interaction', () => {
+  test('test reserve rocket', async () => {
+    render(
+      <React.StrictMode>
+        <Provider store={store}>
+          <Router>
+            <App />
+          </Router>
+        </Provider>
+      </React.StrictMode>,
+    );
+
+    // simulate a API REPOND to the reducer
+    await act(async () => {
+      store.dispatch({ type: 'spacex/rocket/GET_ROCKETS/fulfilled', payload: listRocketTest });
+    });
+
+    // test the first rocket
+    const buttons = screen.getAllByRole('button');
+
+    //reserve 3 rocket
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[1]);
+    fireEvent.click(buttons[2]);
+
+    //Navigate to profile page
+    const profileLink = screen.getAllByRole('link')[2];
+    fireEvent.click(profileLink);
+
+    // check if all elements are displayed in the list of rocket
+    expect(screen.getByText(listRocketTest[0].rocket_name)).toBeTruthy()
+    expect(screen.getByText(listRocketTest[1].rocket_name)).toBeTruthy()
+    expect(screen.getByText(listRocketTest[2].rocket_name)).toBeTruthy()
+  });
+});

--- a/src/components/pages/Profile/Profile.test.js
+++ b/src/components/pages/Profile/Profile.test.js
@@ -2,11 +2,11 @@ import renderer, { act } from 'react-test-renderer';
 import '@testing-library/jest-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
 import configureStore from '../../../redux/configureStore';
 import Profile from './Profile';
-import { fireEvent, render, screen } from '@testing-library/react';
 import App from '../../../App';
-import { Provider } from 'react-redux';
 
 const listRocketTest = [
   {
@@ -70,18 +70,18 @@ describe('test user interaction', () => {
     // test the first rocket
     const buttons = screen.getAllByRole('button');
 
-    //reserve 3 rocket
+    // reserve 3 rocket
     fireEvent.click(buttons[0]);
     fireEvent.click(buttons[1]);
     fireEvent.click(buttons[2]);
 
-    //Navigate to profile page
+    // Navigate to profile page
     const profileLink = screen.getAllByRole('link')[2];
     fireEvent.click(profileLink);
 
     // check if all elements are displayed in the list of rocket
-    expect(screen.getByText(listRocketTest[0].rocket_name)).toBeTruthy()
-    expect(screen.getByText(listRocketTest[1].rocket_name)).toBeTruthy()
-    expect(screen.getByText(listRocketTest[2].rocket_name)).toBeTruthy()
+    expect(screen.getByText(listRocketTest[0].rocket_name)).toBeTruthy();
+    expect(screen.getByText(listRocketTest[1].rocket_name)).toBeTruthy();
+    expect(screen.getByText(listRocketTest[2].rocket_name)).toBeTruthy();
   });
 });

--- a/src/components/pages/Profile/__snapshots__/Profile.test.js.snap
+++ b/src/components/pages/Profile/__snapshots__/Profile.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test render of profile Profile should match snapshoot 1`] = `
+<div
+  className="flex-center"
+>
+  <div
+    className="flex-center column profile-missions"
+  >
+    <h2>
+      mission
+    </h2>
+    <ul
+      className="no-style flex-center column list-reserved"
+    />
+  </div>
+  <div
+    className="flex-center column profile-rockets"
+  >
+    <h2>
+      My Rockets
+    </h2>
+    <ul
+      className="no-style flex-center column list-reserved"
+    >
+      Empty List
+    </ul>
+  </div>
+</div>
+`;


### PR DESCRIPTION
In this pull request, I have been able to (solve the [issue 3](https://github.com/Trast00/SpaceX-Group-Project/issues/3)):
- Add the feature of displaying a list of the reserved rockets on the profile page
- Add test for profile pages